### PR TITLE
classifyLongText(): do not assume that hits is nonempty

### DIFF
--- a/src/main/java/it/polito/tellmefirst/classify/Classifier.java
+++ b/src/main/java/it/polito/tellmefirst/classify/Classifier.java
@@ -136,7 +136,7 @@ public class Classifier {
 			thread.join();
 			ScoreDoc[] hits = thread.getHits();
 			ArrayList<ScoreDoc> hitList = new ArrayList<ScoreDoc>();
-			for (int b = 0; b < numOfTopics; b++) {
+			for (int b = 0; b < numOfTopics && b < hits.length; b++) {
 				hitList.add(hits[b]);
 			}
 			mergedHitList.addAll(hitList);


### PR DESCRIPTION
This pull request makes sure that classifyLongText() does not misbehave when less than seven topics are returned by a classification thread. As far as I understand it, the original code did not had this provision because it was assumed that seven topics were always returned. We now have the problem that we use short indexes for testing, therefore there are cases in which less than seven topics are returned.
