### PR TITLE
Expose classifySmallText()

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,24 @@ Use the API exported by this module as follows:
     TMFVariables variables = new TMFVariables("/path/to/config/file");
     IndexesUtil.init();
 
-    // Classify
+    //
+    // Invoke this to classify text.
+    //
+    // This is the traditional TMF algorithm by which large texts are
+    // divided in chunks classified separately, and the result is generated
+    // merging the classification of each chunk of text.
+    //
     Classifier classifier = new Classifier(language);
     List<String[]> res = classifier.classify(text, numTopics, language);
+
+    //
+    // Alternatively, use classifySmallText to bypass the above policy and
+    // be sure that the whole text is passed to lucene (which, depending on
+    // the text size, may not like it and throw an exception).
+    //
+    Classifier classifier = new Classifier(language);
+    List<String[]> res = classifier.classifySmallText(text,
+                                  numTopics, language);
 
 See also how the API is used by [tmfcore_build_cli](https://github.com/bassosimone/tmfcore_build_cli/blob/master/tmfcore_cli/src/main/java/it/polito/tellmefirst/cli/TMFCoreCli.java) and by
 [tmfcore_build_war](https://github.com/bassosimone/tmfcore_build_war/blob/master/tmfcore_jaxrs/src/main/java/it/polito/tellmefirst/jaxrs/ClassifyResource.java).

--- a/src/main/java/it/polito/tellmefirst/classify/Classifier.java
+++ b/src/main/java/it/polito/tellmefirst/classify/Classifier.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Optional;
 import static java.util.Optional.ofNullable;
 import java.util.TreeMap;
@@ -164,6 +165,29 @@ public class Classifier {
 		result = classifyCore(hits, numOfTopics, lang);
 		LOG.debug("[classifyLongText] - END");
 		return result;
+	}
+
+	/**
+	 * Classify a short piece of text. This function is used to bypass
+	 * the policy by which TMF triggers the long or the short classification
+	 * process depending on the text length. Note that if the text passed
+	 * to this function is too long, lucene may throw an exception.
+	 *
+	 * @param textString the input piece of text.
+	 * @param numOfTopics maximum number of topics to be returned (less
+	 *        topics may be returned.
+	 * @param lang the classifier language (yes, this argument is
+	 *        redundant and will be removed in the future).
+	 * @return A list of vectors of strings. Each vector shall be composed
+	 *         of seven strings: the URI, the label, the title, the
+	 *         score, the merged type, the image, and the wiki link.
+	 *
+	 * @since 2.0.0.0.
+	 */
+	public List<String[]> classifyShortText(String textString,
+			int numOfTopics, String lang) throws InterruptedException,
+			IOException, ParseException {
+		return classifyShortText(new Text(textString), numOfTopics, lang);
 	}
 
 	public ArrayList<String[]> classifyShortText(Text text, int numOfTopics,


### PR DESCRIPTION
I have two use cases for this. First, one may want to be sure that
the result is what lucene returned, not the merge of separately analyzed
chunks of text. Second, one may want to control the size of the chunks,
rather than letting TMFCore decide where to split.
