### PR TITLE
Add a method to get English URI in the SAMEAS field (for the Italian Index)

### DIFF
--- a/src/main/java/it/polito/tellmefirst/lucene/SimpleSearcher.java
+++ b/src/main/java/it/polito/tellmefirst/lucene/SimpleSearcher.java
@@ -146,22 +146,18 @@ public class SimpleSearcher {
 	}
 
     // Used by the Italian classifier
-    public static String getSameAsFromEngToIta(String engUri, SimpleSearcher italianSimpleSearcher) {
+    public static String getSameAsFromEngToIta(String engUri, SimpleSearcher italianSimpleSearcher) throws IOException {
         LOG.debug("[getSameAsFromEngToIta] - BEGIN");
         String result = "";
-        try{
-            IndexSearcher indexSearcher = italianSimpleSearcher.getIndexSearcher();
-            Query q = new TermQuery(new Term("SAMEAS", engUri));
-            TopDocs hits = indexSearcher.search(q, 1);
-            if (hits.totalHits != 0) {
-                int docId = hits.scoreDocs[0].doc;
-                org.apache.lucene.document.Document doc = italianSimpleSearcher.getFullDocument(docId);
-                if (doc.getField("URI") != null){
-                    result = doc.getField("URI").stringValue();
-                }
+        IndexSearcher indexSearcher = italianSimpleSearcher.getIndexSearcher();
+        Query q = new TermQuery(new Term("SAMEAS", engUri));
+        TopDocs hits = indexSearcher.search(q, 1);
+        if (hits.totalHits != 0) {
+            int docId = hits.scoreDocs[0].doc;
+            org.apache.lucene.document.Document doc = italianSimpleSearcher.getFullDocument(docId);
+            if (doc.getField("URI") != null){
+                result = doc.getField("URI").stringValue();
             }
-        } catch (Exception e){
-            LOG.error("[getSameAsFromEngToIta] - EXCEPTION: ", e);
         }
         LOG.debug("[getSameAsFromEngToIta] - END");
         return result;

--- a/src/main/java/it/polito/tellmefirst/lucene/SimpleSearcher.java
+++ b/src/main/java/it/polito/tellmefirst/lucene/SimpleSearcher.java
@@ -144,4 +144,26 @@ public class SimpleSearcher {
 		LOG.debug("[getTypes] - END");
 		return result;
 	}
+
+    // Used by the Italian classifier
+    public static String getSameAsFromEngToIta(String engUri, SimpleSearcher italianSimpleSearcher) {
+        LOG.debug("[getSameAsFromEngToIta] - BEGIN");
+        String result = "";
+        try{
+            IndexSearcher indexSearcher = italianSimpleSearcher.getIndexSearcher();
+            Query q = new TermQuery(new Term("SAMEAS", engUri));
+            TopDocs hits = indexSearcher.search(q, 1);
+            if (hits.totalHits != 0) {
+                int docId = hits.scoreDocs[0].doc;
+                org.apache.lucene.document.Document doc = italianSimpleSearcher.getFullDocument(docId);
+                if (doc.getField("URI") != null){
+                    result = doc.getField("URI").stringValue();
+                }
+            }
+        } catch (Exception e){
+            LOG.error("[getSameAsFromEngToIta] - EXCEPTION: ", e);
+        }
+        LOG.debug("[getSameAsFromEngToIta] - END");
+        return result;
+    }
 }


### PR DESCRIPTION
Lucene Documents of the Italian Corpus Index contain a "SAMEAS" field in which the corresponding English URI of an Italian concept/entity is stored.

For these reasons it is necessary define a new method of the SimpleSearcher class of tmfcore in order to retrieve that information at the Enhancement stage.