### PR TITLE
Correct bad implementation of getSameAsFromEngToIta()

### DIFF
--- a/src/main/java/it/polito/tellmefirst/lucene/SimpleSearcher.java
+++ b/src/main/java/it/polito/tellmefirst/lucene/SimpleSearcher.java
@@ -146,15 +146,14 @@ public class SimpleSearcher {
 	}
 
     // Used by the Italian classifier
-    public static String getSameAsFromEngToIta(String engUri, SimpleSearcher italianSimpleSearcher) throws IOException {
+    public String getSameAsFromEngToIta(String uri) throws IOException {
         LOG.debug("[getSameAsFromEngToIta] - BEGIN");
         String result = "";
-        IndexSearcher indexSearcher = italianSimpleSearcher.getIndexSearcher();
-        Query q = new TermQuery(new Term("SAMEAS", engUri));
-        TopDocs hits = indexSearcher.search(q, 1);
+        Query q = new TermQuery(new Term("SAMEAS", uri));
+        TopDocs hits = getIndexSearcher().search(q, 1);
         if (hits.totalHits != 0) {
             int docId = hits.scoreDocs[0].doc;
-            org.apache.lucene.document.Document doc = italianSimpleSearcher.getFullDocument(docId);
+            Document doc = getFullDocument(docId);
             if (doc.getField("URI") != null){
                 result = doc.getField("URI").stringValue();
             }


### PR DESCRIPTION
I have cleaned getSameAsFromEngToIta(), because it was too similar to the TellMeFirst legacy implementation of the method.

Now, it is suitable for current implementation of tmfcore.

